### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ name = "qstdin"
 version = "0.1.1"
 authors = ["TanmayPatil105 <tanmaynpatil105@gmail.com"]
 description = "Interface for querying stdin"
-homepage = "https://github.com/TanmayPatil105/qstdin"
+repository = "https://github.com/TanmayPatil105/qstdin"
 license =  "GPL-3.0-or-later"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.